### PR TITLE
feat: Version the package with MinVer instead of a manual CI step

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -32,6 +32,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # MinVer derives the version from git tags and the commit count above them, so it needs the
+          # actual history rather than actions/checkout's default shallow clone - which contains no
+          # tags to find.
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -41,17 +46,13 @@ jobs:
           # build with, and testing on what people use beats testing on the oldest thing that works.
           dotnet-version: '10.x'
 
-      # On a tag the tag is the version, so nothing in the repository can disagree with what shipped.
-      # Off a tag this is unset and expands to nothing, leaving the csproj's own <Version> - which is
-      # then only ever a local default, never the thing that gets published.
-      - name: Take the version from the tag
-        if: github.ref_type == 'tag'
-        run: echo "VERSION_ARG=-p:Version=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
-
       # No NuGet.config and no secure file: every dependency is public on nuget.org. The Azure
       # pipeline this replaced downloaded a secure NuGet.config it did not need.
+      #
+      # No -p:Version here: MinVer sets it from the git tag (and the commit count above one, off a
+      # tag), so nothing in the repository can disagree with what shipped.
       - name: Build
-        run: dotnet build Nota.CodeAnalysis.sln --configuration Release $VERSION_ARG
+        run: dotnet build Nota.CodeAnalysis.sln --configuration Release
 
       - name: Verify the rules report
         run: ./Nota.CodeAnalysis.Verification/verify.sh
@@ -67,7 +68,7 @@ jobs:
         run: ./Nota.CodeAnalysis.Verification/verify-package.sh
 
       - name: Pack
-        run: dotnet pack Nota.CodeAnalysis.sln --configuration Release --no-build --output artifacts $VERSION_ARG
+        run: dotnet pack Nota.CodeAnalysis.sln --configuration Release --no-build --output artifacts
 
       # Kept even on a pull request, so a packaging mistake is visible without merging.
       - name: Upload the package

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- Tags are "v2.2.0", not "2.2.0" - MinVer's default prefix is empty, so without this it would
+         never find a tag and every build would fall back to 0.0.0-alpha.0. -->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
+</Project>

--- a/Nota.CodeAnalysis.Verification/verify-package.sh
+++ b/Nota.CodeAnalysis.Verification/verify-package.sh
@@ -40,10 +40,14 @@ mkdir -p "$feed" "$app"
 # whatever 2.2.0 was extracted first - the change under test never reaches the consumer. That is not
 # hypothetical; this script gave a clean pass against a regression it was written to catch, until the
 # version was made unique.
+#
+# MinVerVersionOverride, not -p:Version - MinVer computes Version itself from the git tag and
+# overwrites whatever was passed in, so -p:Version here would be silently ignored and every run
+# would collide on the same version, reviving the exact bug this comment describes.
 version="0.0.0-verify.$(date +%Y%m%d%H%M%S)"
 
 printf 'Packing %s...\n' "$version"
-dotnet pack "$root/Nota.CodeAnalysis.sln" --configuration Release --output "$feed" -p:Version="$version" >"$work/pack.log" 2>&1 || {
+dotnet pack "$root/Nota.CodeAnalysis.sln" --configuration Release --output "$feed" -p:MinVerVersionOverride="$version" >"$work/pack.log" 2>&1 || {
     printf 'pack failed:\n' >&2
     cat "$work/pack.log" >&2
     exit 1

--- a/Nota.CodeAnalysis/Nota.CodeAnalysis.csproj
+++ b/Nota.CodeAnalysis/Nota.CodeAnalysis.csproj
@@ -4,9 +4,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/Notalib/Nota.CodeAnalysis</RepositoryUrl>
     <NoDefaultExcludes>true</NoDefaultExcludes>
-    <!-- A local default only. Releases take their version from the git tag, so this is what you get
-         packing by hand and never what gets published. -->
-    <Version>2.2.1</Version>
     <PackageReadmeFile>content/README.md</PackageReadmeFile>
   </PropertyGroup>
 
@@ -25,6 +22,11 @@
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
     <PackageReference Include="UsingLayoutAnalyser" Version="0.3.0" />
+
+    <!-- Sets Version from the nearest git tag (Directory.Build.props declares the "v" prefix) plus a
+         height above it, so the package version can never drift from what was actually tagged. Build-
+         time only: PrivateAssets stops it flowing to consumers, who have no reason to inherit it. -->
+    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -144,8 +144,12 @@ Releases are cut by tagging:
 git tag -a v2.3.0 -m "Nota.CodeAnalysis 2.3.0" && git push origin v2.3.0
 ```
 
-The tag is the version, so nothing in the repository can disagree with what shipped. `<Version>` in
-the csproj is only a local default, for anyone packing by hand.
+[MinVer](https://github.com/adamralph/minver) derives the package version from that tag on every
+build, so nothing in the repository can disagree with what shipped - there is no `<Version>` to edit
+or forget to bump. Building straight off a tagged commit gets that tag's version exactly; anything
+else gets the next patch as a pre-release with the commit count above the tag, e.g. `2.3.1-alpha.0.4`.
+CI checks out full history (`fetch-depth: 0`) so MinVer can see the tags at all - a shallow clone has
+none, and would fall back to `0.0.0-alpha.0`.
 
 Merging to `main` builds and verifies but does not publish, and neither do pull requests - releasing
 is a separate act from merging.


### PR DESCRIPTION
## Summary

Replaces the hand-maintained "take the version from the tag" CI step with [MinVer](https://github.com/adamralph/minver), so the package version is always derived from the nearest git tag (and commit height above it) rather than a value that has to be kept in sync by hand.

## Changes

- **`Directory.Build.props`** (new): sets `MinVerTagPrefix` to `v`, matching this repo's `v2.2.0`-style tags.
- **`Nota.CodeAnalysis.csproj`**: adds a `PackageReference` to `MinVer` (`PrivateAssets="All"`, build-time only) and removes the hardcoded `<Version>2.2.1</Version>`.
- **`.github/workflows/build-and-publish.yml`**: checkout now uses `fetch-depth: 0` (MinVer needs tag history to compute height), and the manual "take the version from the tag" step plus `$VERSION_ARG` plumbing is removed — MinVer sets `Version` on every build automatically.
- **`Nota.CodeAnalysis.Verification/verify-package.sh`**: switches from `-p:Version` to `-p:MinVerVersionOverride`. MinVer recalculates `Version` itself and would otherwise silently overwrite the `-p:Version` override, causing every verification run to collide on the same package version — the exact caching bug the script's own comment already warns about.

## Verification

- `dotnet build`/`dotnet pack` on the solution succeed, and pack correctly derives `2.2.1-alpha.0.1` off the current `v2.2.0` tag (would be exactly `2.2.0` if built directly on that tag).
- `verify.sh`, `verify-encoding.sh`, and `verify-package.sh` all pass.