### PR TITLE
Drop the two import keys that wedge dotnet format

### DIFF
--- a/Nota.CodeAnalysis.Verification/README.md
+++ b/Nota.CodeAnalysis.Verification/README.md
@@ -48,15 +48,24 @@ looks redundant and is not: without it `IDE0005` silently stops reporting.
 
 ## What `verify.sh` asserts
 
-`Samples/Broken.cs` breaks each of these deliberately.
+`Samples/Broken.cs` and `Samples/Unseparated.cs` break each of these deliberately.
 
-| Rule      | What it catches                              |
-|-----------|----------------------------------------------|
-| `IDE0005` | an unused using - what CS8019 never did       |
-| `IDE0008` | `var` instead of an explicit type             |
-| `UA1000`  | using directives out of order                 |
-| `SA1208`  | System usings not placed first                |
-| `SA1516`  | no blank line after the System group          |
+| Rule      | What it catches                                  | Sample           |
+|-----------|--------------------------------------------------|------------------|
+| `IDE0005` | an unused using - what CS8019 never did          | `Broken.cs`      |
+| `IDE0008` | `var` instead of an explicit type                | `Broken.cs`      |
+| `UA1000`  | using directives out of order                    | `Broken.cs`      |
+| `SA1208`  | System usings not placed first                   | `Broken.cs`      |
+| `UA1001`  | no blank line between using blocks               | `Unseparated.cs` |
+| `SA1516`  | no blank line between members                    | `Unseparated.cs` |
+
+`SA1516` used to be the one asserting the blank line after the System group, and that worked only
+because `dotnet_separate_import_directive_groups` was set. The key had to go - at *any* value,
+including `false`, its presence arms the organize-imports stage of `dotnet format style`, which sorts
+first party above the vendors and leaves `dotnet format --verify-no-changes` failing permanently with
+nothing a consumer can do about it. `UA1001` makes that check now, and distinguishes first party from
+vendor where `SA1516` only ever saw first-level namespaces. `SA1516` stays asserted on member
+separation, which was always its own job.
 
 ## What `verify-encoding.sh` asserts
 

--- a/Nota.CodeAnalysis.Verification/Samples/Unseparated.cs
+++ b/Nota.CodeAnalysis.Verification/Samples/Unseparated.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Xml;
+using Nota.Vendor;
+
+namespace Nota.Verification;
+
+/// <summary>
+/// Two deliberate faults, both asserted by verify.sh.
+///
+/// The using directives are in the right order and have no blank line between the blocks, which
+/// UA1001 reports. SA1516 used to report that, but only because
+/// dotnet_separate_import_directive_groups was set - and setting that key at any value arms the
+/// organize-imports stage of "dotnet format style", which sorts first party above the vendors and
+/// leaves "dotnet format --verify-no-changes" failing forever. The key is gone; UA1001 makes the
+/// check now, and knows first party from vendor where SA1516 only ever saw first-level namespaces.
+///
+/// The two members below have no blank line between them either. That is SA1516's own job and
+/// nothing to do with usings, so it stays asserted here rather than leaving with the key. They carry
+/// no documentation comments on purpose: a comment between them would be reported by SA1514 instead,
+/// and SA1600 is off here, so their absence costs nothing.
+/// </summary>
+public static class Unseparated
+{
+    public static string First => typeof(Thing).Name;
+    public static string Second => typeof(XmlDocument).Name + Environment.NewLine;
+}

--- a/Nota.CodeAnalysis.Verification/verify.sh
+++ b/Nota.CodeAnalysis.Verification/verify.sh
@@ -31,12 +31,16 @@ done
 #    IDE0005   unused using directive          the one CS8019 was supposed to cover
 #    IDE0008   var instead of an explicit type
 #    UA1000    using directives out of order   UsingLayoutAnalyser
+#    UA1001    no blank line between using blocks - see Samples/Unseparated.cs. SA1516 used to cover
+#              this, but only because dotnet_separate_import_directive_groups was set, and that key
+#              had to go: at any value it arms dotnet format's organize-imports stage, which sorts
+#              first party above the vendors and leaves --verify-no-changes failing permanently
 #    SA1208    System usings not placed first
-#    SA1516    no blank line after the System group
+#    SA1516    no blank line between members - its own job, not the using one it lost
 #    NOTA0001  a source file that is not valid UTF-8, from build/Nota.CodeAnalysis.targets - the one
 #              rule here that is a build error rather than an analyser diagnostic, and so the only
 #              one that cannot be confirmed by reading a severity out of the globalconfig
-expected=(IDE0005 IDE0008 UA1000 SA1208 SA1516 NOTA0001)
+expected=(IDE0005 IDE0008 UA1000 UA1001 SA1208 SA1516 NOTA0001)
 
 # VerifyRules is what pulls Samples/ into the compilation. Without it the project builds empty, which
 # is what every other build of this solution wants.

--- a/Nota.CodeAnalysis/content/Nota.CodeAnalysis.globalconfig
+++ b/Nota.CodeAnalysis/content/Nota.CodeAnalysis.globalconfig
@@ -7,14 +7,27 @@ end_of_line = crlf
 
 # Stylecop settings
 ## Using Directives
-dotnet_sort_system_directives_first = true
-
-# Half of this is enforced and half is not, so do not read it as a promise. SA1516 uses it to require
-# the blank line after the System group, and that part works. The per-vendor grouping the name
-# suggests - Microsoft together, Serilog together - is checked by IDE0055 only, which is off here, so
-# nothing reports it. UsingLayoutAnalyser below is what actually enforces the grouping; this stays
-# for the System boundary, and because turning it off would silence that too.
-dotnet_separate_import_directive_groups = true
+#
+# dotnet_sort_system_directives_first and dotnet_separate_import_directive_groups are deliberately
+# absent, and must stay absent. Not set to false - absent. Their presence at any value arms the
+# organize-imports stage of "dotnet format style", which reports as "error IMPORTS: Fix imports
+# ordering" and sorts flat-alphabetically after System. That puts Nota above the vendors, which is
+# the inverse of the layout UA1000 enforces below.
+#
+# The result is a loop rather than a wrong file. The style stage reorders, the analyzers stage puts
+# it back, the file on disk never changes - so "dotnet format" reports nothing to do while
+# "dotnet format --verify-no-changes" exits 2 forever, and CI cannot be made green. Measured against
+# a real consumer, not reasoned about.
+#
+# This stage is not a diagnostic. It has no ID and no severity, and setting
+# dotnet_diagnostic.IDE0055.severity = none does not reach it - which is what the earlier note here
+# got wrong: it checked what reports, not what enforces. Rider is unaffected, so this only ever bites
+# whoever formats from the command line.
+#
+# Cost of their absence, measured: SA1516 no longer reports a missing blank line between using
+# groups, which dotnet_separate_import_directive_groups = true did give us. UA1001 already requires
+# that blank line and knows first party from vendor, where SA1516 only saw first-level namespaces, so
+# what goes is the blunter duplicate of a check we still have.
 
 ## Using layout - UsingLayoutAnalyser (UA1000, UA1001)
 # System, then third party, then the consuming solution's own namespaces, as blocks separated by a

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ Most of this is unsurprising. These are the ones that catch people out:
 - **`UA1000` and `UA1001`** enforce the using layout: System, then third party, then yours, as blocks
   separated by a blank line, one run per vendor. An existing repository is converted in one pass with
   `dotnet format analyzers --diagnostics UA1000 UA1001 --severity warn`.
+- **Do not set `dotnet_sort_system_directives_first` or `dotnet_separate_import_directive_groups`.**
+  Not even to `false`. This package leaves both keys out on purpose, and an `.editorconfig` entry
+  beats a global analyzer config entry, so putting one back is the one override here that breaks
+  something. Their presence at any value arms the organize-imports stage of `dotnet format style`,
+  which sorts flat-alphabetically after System and so puts your namespaces above the vendors -
+  the inverse of what `UA1000` requires. The two then take turns: the style stage reorders, the
+  analyzers stage puts it back, the file on disk never changes, and `dotnet format` reports nothing
+  to do while `dotnet format --verify-no-changes` exits 2 forever. It is not a diagnostic and no
+  severity setting reaches it. Rider is unaffected, so this only bites the command line and CI.
 
 ## Turning things off
 


### PR DESCRIPTION
## The problem

A consuming repository reported that `dotnet format` would not fix its using order, while the build kept failing on `UA1000`. Reproduced and measured: as shipped, three consecutive `dotnet format` runs leave the file byte-identical and `dotnet format --verify-no-changes` exits 2 every time.

```
after dotnet format run #1 -> verify EXIT=2  | md5 5cf85de64fb803cfd6e94c406ab9a686
after dotnet format run #2 -> verify EXIT=2  | md5 5cf85de64fb803cfd6e94c406ab9a686
after dotnet format run #3 -> verify EXIT=2  | md5 5cf85de64fb803cfd6e94c406ab9a686
```

The file on disk is already correct. There is nothing the consumer can do to make CI green.

## Cause

`dotnet format style` runs an organize-imports stage, reported as `error IMPORTS: Fix imports ordering`. It switches on if and only if `dotnet_sort_system_directives_first` or `dotnet_separate_import_directive_groups` is explicitly set — **at any value, including `false`**. Isolated each:

| setting | `dotnet format --verify-no-changes` |
|---|---|
| `dotnet_sort_system_directives_first = true` | **EXIT=2** |
| `dotnet_separate_import_directive_groups = true` | **EXIT=2** |
| `dotnet_separate_import_directive_groups = false` | **EXIT=2** |
| both absent | EXIT=0 |

Once armed it sorts flat-alphabetically after System, putting `Nota.*` above the vendors — the inverse of UA1000's third block. The style stage reorders, the analyzers stage puts it back, the file never changes on disk, and `--verify-no-changes` reports what the style stage wanted.

The note in the globalconfig reasoned that the per-vendor grouping was "checked by IDE0055 only, which is off here, so nothing reports it". True, and beside the point — the imports stage is not a diagnostic, has no severity, and `dotnet_diagnostic.IDE0055.severity = none` does not reach it. It checked what *reports*, not what *enforces*. Rider is unaffected, which is why this only ever bit whoever formats from the command line.

## The change

Both keys removed from `content/Nota.CodeAnalysis.globalconfig`, with a comment recording why they must stay absent rather than be set to `false`.

## What it costs, measured

`SA1516` does lose one check. With UA silenced, on usings with no blank line after the System group:

```
dotnet_separate_import_directive_groups = ABSENT -> SA1516 hits: 0
dotnet_separate_import_directive_groups = true   -> SA1516 hits: 2
dotnet_separate_import_directive_groups = false  -> SA1516 hits: 0
```

`UA1001` already requires that blank line, and knows first party from vendor where `SA1516` only ever saw first-level namespaces. What goes is the blunter duplicate of a check we still have.

## Verification

Removing the key broke `verify.sh`, which asserted `SA1516` for exactly that blank line — the suite doing its job:

```
Verification failed:
  - SA1516 did not report - it is configured but not reaching consumers
```

`Samples/Unseparated.cs` now carries both faults: using blocks in the right order with no blank line between them (`UA1001`), and two members with no blank line between them (`SA1516`, on its own turf). Its members carry no doc comments deliberately — a comment between them is reported by `SA1514` instead, and `SA1600` is off here.

All three scripts pass:

```
verify.sh:             All 7 rules reported.
verify-encoding.sh:    All source files are valid UTF-8 or BOM-marked UTF-16.
verify-package.sh:     All rules survive packaging.
```

End to end against the reporting consumer's own two `.editorconfig` files: one `dotnet format` pass produces the canonical layout and `--verify-no-changes` exits 0 repeatedly.

## Note for consumers

An `.editorconfig` entry beats a global analyzer config entry, so a consumer can re-arm this from their own repository. Both READMEs now say not to set either key, not even to `false`.

## Interim workaround

Until this ships, a consumer on the current package can skip the `style` stage — verified against the published config:

```
dotnet format whitespace && dotnet format analyzers
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)