### PR TITLE
Take UsingLayoutAnalyser 0.4.0, for UA1002

### DIFF
--- a/Nota.CodeAnalysis.Verification/Nota.CodeAnalysis.Verification.csproj
+++ b/Nota.CodeAnalysis.Verification/Nota.CodeAnalysis.Verification.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-    <PackageReference Include="UsingLayoutAnalyser" Version="0.3.0" />
+    <PackageReference Include="UsingLayoutAnalyser" Version="0.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Nota.CodeAnalysis/Nota.CodeAnalysis.csproj
+++ b/Nota.CodeAnalysis/Nota.CodeAnalysis.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-    <PackageReference Include="UsingLayoutAnalyser" Version="0.3.0" />
+    <PackageReference Include="UsingLayoutAnalyser" Version="0.4.0" />
 
     <!-- Sets Version from the nearest git tag (Directory.Build.props declares the "v" prefix) plus a
          height above it, so the package version can never drift from what was actually tagged. Build-

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Most of this is unsurprising. These are the ones that catch people out:
   analyzers stage puts it back, the file on disk never changes, and `dotnet format` reports nothing
   to do while `dotnet format --verify-no-changes` exits 2 forever. It is not a diagnostic and no
   severity setting reaches it. Rider is unaffected, so this only bites the command line and CI.
+- **`UA1002`** is what tells you the above, rather than leaving you to remember it. It reports once
+  per project on either of those keys being present at any value, and on
+  `dotnet_diagnostic.SA1210.severity` being turned up to `warning` or `error` - SA1210 has a fix of
+  its own, and under `dotnet format` its fix and `UA1000`'s undo each other, so the file changes on
+  every run. It arrived with UsingLayoutAnalyser 0.4.0. Silence from it is not a clean bill of
+  health: SA1210 left unset is StyleCop's own default, which no analyser can read, so unset is
+  unknown rather than safe.
 
 ## Turning things off
 


### PR DESCRIPTION
Follow-on to #11. That removed the two `.editorconfig` keys that wedged `dotnet format`; this takes the analyser version that stops them coming back.

## What 0.4.0 adds

`UA1002` reports, once per project, the settings that make something else rewrite the using block:

| Detected | Condition |
|---|---|
| `dotnet_sort_system_directives_first` | present at **any** value |
| `dotnet_separate_import_directive_groups` | present at **any** value |
| `dotnet_diagnostic.SA1210.severity` | `warning` or `error` |

Presence rather than value for the first two, because presence is the trigger — `= false` reads like switching the thing off and does exactly what `= true` does. That is the specific misunderstanding this package shipped for two releases.

`SA1210` is in there because it is the same class of problem and the more expensive one. It has a fix of its own, so under `dotnet format` its fix and `UA1000`'s undo each other and the file changes on every run — a real diff every time anyone formats, rather than the stable-but-unpassable state the import keys produce.

## Why this matters here rather than being a version bump

The globalconfig carried both keys with a comment explaining why they were harmless. They were not. They wedged `dotnet format` for every consumer who formats from a command line, permanently, with no way for the consumer to fix it — an `.editorconfig` cannot unset a globalconfig key, and setting it to `false` makes no difference. It took a downstream repository losing a day to find out, and #11 was the fix. This is the part that means nobody has to remember.

## Verified, not assumed

The keys are gone from here, so `UA1002` is silent in this repository — and silence is exactly what a rule that never arrived looks like, which is the failure mode this repository exists to be paranoid about. So it was checked both ways:

```
with dotnet_separate_import_directive_groups = false added to the verification project:
  warning UA1002: 'dotnet_separate_import_directive_groups' will fight the layout UA1000 enforces - remove the key, ...

with it removed again:
  UA1002 reports: 0
```

That is `UA1002` arriving through the installed package, not through a project reference.

All three scripts pass, and the build is clean:

```
verify.sh:             All 7 rules reported.
verify-encoding.sh:    All source files are valid UTF-8 or BOM-marked UTF-16.
verify-package.sh:     All rules survive packaging.
```

## Consumer impact — please read before merging

**This is a behaviour change, not a dependency bump.** Consumers get a new warning for configuration they already had.

An `.editorconfig` entry beats a global analyzer config entry, so setting either key in a consuming repository was always available and was, until recently, advice in UsingLayoutAnalyser's own README. Any repository that did so will now see `UA1002`, and under `TreatWarningsAsErrors` its build stops.

That is the rule working — their build was already broken in the way that mattered, and only `dotnet format` knew — but it should go out as a **minor release rather than a patch**, so `v2.3.0` rather than `v2.2.3`.

## What it does not catch

`SA1210` left unset is StyleCop's own default, and no analyser can read another package's defaults, so unset is *unknown* rather than safe. Below `warning` it stays quiet on purpose: `dotnet format` fixes at `warn` and above unless told otherwise, so a suggestion puts no second fix in play. Both are in the README rather than implied away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)